### PR TITLE
リクルート2027年リンク更新

### DIFF
--- a/recruit/index.html
+++ b/recruit/index.html
@@ -213,8 +213,7 @@
 				</div>
 				<div class="elementor-element elementor-element-5ae0ee3 elementor-widget elementor-widget-text-editor" data-id="5ae0ee3" data-element_type="widget" data-widget_type="text-editor.default">
 				<div class="elementor-widget-container">
-								<figure class="image"><!-- Begin mynavi Navi Link --><a href="https://job.mynavi.jp/26/pc/search/corp112634/outline.html" target="_blank"><img class="aligncenter" style="width: 195px; height: 45px;" src="https://job.mynavi.jp/conts/kigyo/2026/logo/banner_mynavi_160_45.gif" alt="マイナビ2026" border="0"></a><!-- End mynavi Navi Link --></figure>
-</div>
+								<figure class="image"><!-- Begin mynavi Navi Link --><a href="https://job.mynavi.jp/27/pc/search/corp112634/outline.html" target="_blank"><img src="https://job.mynavi.jp/conts/kigyo/2027/logo/banner_logo_195_60.gif" alt="マイナビ2027" border="0"></a><!-- End mynavi Navi Link --></figure></div>
 				</div>
 					</div>
 		</div>


### PR DESCRIPTION
「新卒採用」のマイナビバナーを2027版に変更